### PR TITLE
mongo dockerfile fixes, call pm2-runtime directly in docker

### DIFF
--- a/packages/serve1090/CHANGELOG.md
+++ b/packages/serve1090/CHANGELOG.md
@@ -5,7 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+- upgrade node to v16.13.0
 ### Fixed
+- mongo dockerfile issues
+- pm2-runtime directly called in express Dockerfile
 ### Removed
 ### Breaking
 

--- a/packages/serve1090/docker/express/Dockerfile
+++ b/packages/serve1090/docker/express/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR $APP_DIR
 
 COPY package.json package-lock.json $APP_DIR/
 
+RUN npm i -g pm2
 RUN npm ci
 
 COPY index.js $APP_DIR

--- a/packages/serve1090/docker/express/docker-entrypoint.sh
+++ b/packages/serve1090/docker/express/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$NODE_ENV" = "production" ]; then
-  npm run pm2
+  pm2-runtime index.js
 else
   npm run debug
 fi

--- a/packages/serve1090/docker/mongo/b-seed-data.sh
+++ b/packages/serve1090/docker/mongo/b-seed-data.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
 # note: init scripts are run alphabetically by filename
+function import {
+  mongoimport --db serve1090 --collection $1 --file $file --username $MONGO_USERNAME --password $MONGO_PASSWORD --authenticationDatabase admin
+}
+
 for file in /data/seed_data/airports/*; do
   import airports
 done
@@ -9,6 +13,3 @@ for file in /data/seed_data/airspaces/*; do
   import airspaces
 done
 
-function import {
-  mongoimport --db serve1090 --collection $1 --file $file --username $MONGO_USERNAME --password $MONGO_PASSWORD --authenticationDatabase admin
-}

--- a/packages/serve1090/package-lock.json
+++ b/packages/serve1090/package-lock.json
@@ -26,7 +26,7 @@
         "nanoid": "^3.1.23",
         "p-map": "^4.0.0",
         "pino": "^6.12.0",
-        "pm2": "^5.1.0",
+        "pm2": "^5.1.2",
         "safe-compare": "^1.1.4"
       },
       "devDependencies": {
@@ -3284,17 +3284,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "node_modules/fast-printf": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.6.tgz",
-      "integrity": "sha512-Uz/uW6R1Fd8YqCGeoQosRIfB4dBbr8uMbFVdEci2AyXYcfucFqhpSMAGs8skRRdZd+MGCDBu48+B8Zmu7Pta5A==",
-      "dependencies": {
-        "boolean": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10.0"
-      }
-    },
     "node_modules/fast-redact": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
@@ -6540,9 +6529,9 @@
       }
     },
     "node_modules/pm2": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.1.0.tgz",
-      "integrity": "sha512-reJ35NOxM4+g7H0enW47HJsp32CszKkseCojAuUMUkffyXsGDKBMnDqhxAZMZKtHUUjl0cWFEqKehqB0ODH8Kw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.1.2.tgz",
+      "integrity": "sha512-2nJQeCWjkN0WnTkWctaoZpqrJTiUN/Icw76IMVHHzPhr/p7yQYlEQgHzlL5IFWxO2N1HdBNXNdZft2p4HUmUcA==",
       "dependencies": {
         "@pm2/agent": "~2.0.0",
         "@pm2/io": "~5.0.0",
@@ -6559,7 +6548,6 @@
         "debug": "^4.3.1",
         "enquirer": "2.3.6",
         "eventemitter2": "5.0.1",
-        "fast-printf": "^1.3.0",
         "fclone": "1.0.11",
         "mkdirp": "1.0.4",
         "needle": "2.4.0",
@@ -6571,6 +6559,7 @@
         "promptly": "^2",
         "semver": "^7.2",
         "source-map-support": "0.5.19",
+        "sprintf-js": "1.1.2",
         "vizion": "~2.2.1",
         "yamljs": "0.3.0"
       },
@@ -7461,8 +7450,7 @@
     "node_modules/sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "node_modules/stack-utils": {
       "version": "2.0.5",
@@ -11058,14 +11046,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
-    "fast-printf": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/fast-printf/-/fast-printf-1.6.6.tgz",
-      "integrity": "sha512-Uz/uW6R1Fd8YqCGeoQosRIfB4dBbr8uMbFVdEci2AyXYcfucFqhpSMAGs8skRRdZd+MGCDBu48+B8Zmu7Pta5A==",
-      "requires": {
-        "boolean": "^3.0.2"
-      }
-    },
     "fast-redact": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.0.tgz",
@@ -13550,9 +13530,9 @@
       }
     },
     "pm2": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.1.0.tgz",
-      "integrity": "sha512-reJ35NOxM4+g7H0enW47HJsp32CszKkseCojAuUMUkffyXsGDKBMnDqhxAZMZKtHUUjl0cWFEqKehqB0ODH8Kw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/pm2/-/pm2-5.1.2.tgz",
+      "integrity": "sha512-2nJQeCWjkN0WnTkWctaoZpqrJTiUN/Icw76IMVHHzPhr/p7yQYlEQgHzlL5IFWxO2N1HdBNXNdZft2p4HUmUcA==",
       "requires": {
         "@pm2/agent": "~2.0.0",
         "@pm2/io": "~5.0.0",
@@ -13569,7 +13549,6 @@
         "debug": "^4.3.1",
         "enquirer": "2.3.6",
         "eventemitter2": "5.0.1",
-        "fast-printf": "^1.3.0",
         "fclone": "1.0.11",
         "mkdirp": "1.0.4",
         "needle": "2.4.0",
@@ -13582,6 +13561,7 @@
         "promptly": "^2",
         "semver": "^7.2",
         "source-map-support": "0.5.19",
+        "sprintf-js": "1.1.2",
         "vizion": "~2.2.1",
         "yamljs": "0.3.0"
       },
@@ -14280,8 +14260,7 @@
     "sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
-      "dev": true
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
     },
     "stack-utils": {
       "version": "2.0.5",

--- a/packages/serve1090/package.json
+++ b/packages/serve1090/package.json
@@ -7,7 +7,7 @@
   "author": "Robert Steilberg <rsteilberg@gmail.com>",
   "scripts": {
     "start": "node index.js",
-    "pm2": "pm2-runtime index.js",
+    "pm2": "pm2 index.js",
     "debug": "nodemon --inspect=0.0.0.0 index.js",
     "d": "npm run debug",
     "test": "jest",
@@ -34,7 +34,7 @@
     "nanoid": "^3.1.23",
     "p-map": "^4.0.0",
     "pino": "^6.12.0",
-    "pm2": "^5.1.0",
+    "pm2": "^5.1.2",
     "safe-compare": "^1.1.4"
   },
   "devDependencies": {
@@ -47,7 +47,7 @@
     "superwstest": "^1.8.0"
   },
   "volta": {
-    "node": "16.5.0",
-    "npm": "7.19.1"
+    "node": "16.13.0",
+    "npm": "8.1.4"
   }
 }


### PR DESCRIPTION
## 1. Description of changes:

### `serve1090`
* mongo dockerfile issues
* pm2-runtime directly called in express Dockerfile

### `pump1090`
none

### `dump1090`
none

### `piTemp`
none

## 2. Releases:
none at this time

- [x] updated changelog
